### PR TITLE
Add link to Reveal.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install via NPM: `npm install caniuse-component` -- include the js and css sourc
 
 ### Reveal.js Implementation
 
-To use this with [Reveal.js](#), npm install, then apply this source as a plugin:
+To use this with [Reveal.js](https://github.com/hakimel/reveal.js/), npm install, then apply this source as a plugin:
 
 ```
 Reveal.initialize({


### PR DESCRIPTION
It seems that the URL to [Reveal.js](https://github.com/hakimel/reveal.js/) is missing in the README, this PR will fix that 😊 